### PR TITLE
Clear AUTO_COMMAND in the precmd hook

### DIFF
--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -54,6 +54,7 @@ function _auto_notify_send() {
     if [[ -n "$AUTO_COMMAND" && $elapsed -gt $AUTO_NOTIFY_THRESHOLD ]]; then
         _auto_notify_message "$AUTO_COMMAND" "$elapsed"
     fi
+    AUTO_COMMAND=""
 }
 
 function _auto_notify_track() {


### PR DESCRIPTION
precmd is always triggered before a new prompt is returned, but preexec is only called before an actual command is executed.
This means that using builtins (or using ^C or enter) on an empty commandline will result in a new notification for the previous command that has already completed before.