### PR TITLE
 In some zsh setups, when history is disabled, $1 is always empty. 

### DIFF
--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -63,7 +63,10 @@ function _auto_notify_send() {
 }
 
 function _auto_notify_track() {
-    AUTO_COMMAND="$1"
+    # $1 is the string the user typed, but only when history is enabled
+    # $2 is a single-line, size-limited version of the command that is always available
+    # To still do something useful when history is disabled, although with reduced functionality, fall back to $2 when $1 is empty
+    AUTO_COMMAND="${1:-$2}"
     AUTO_COMMAND_FULL="$3"
     AUTO_COMMAND_START="$(date +"%s")"
 }


### PR DESCRIPTION
When history is disabled, $1 is always empty, but the command is present in $2 and $3.
To get at least some functionality, although commands without aliases expanded are not available now, use $2 when $1 is empty.

This happens in my case, because the default history is disabled and replaced with the oh-my-zsh [per-directory-history](https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/per-directory-history) plugin.