### PR TITLE
Improve notifications on macOS

### DIFF
--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -42,10 +42,11 @@ function _auto_notify_message() {
         fi
         notify-send "$title" "$body" "--urgency=$urgency" "--expire-time=$AUTO_NOTIFY_EXPIRE_TIME"
     elif [[ "$platform" == "Darwin" ]]; then
-        # We need to escape quotes since we are passing a script into a command
-        body="${body//\"/\\\"}"
-        title="${title//\"/\\\"}"
-        osascript -e "display notification \"$body\" with title \"$title\""
+        osascript \
+          -e 'on run argv' \
+          -e 'display notification (item 1 of argv) with title (item 2 of argv)' \
+          -e 'end run' \
+          "$body" "$title"
     else
         printf "Unknown platform for sending notifications: $platform\n"
         printf "Please post an issue on gitub.com/MichaelAquilina/zsh-auto-notify/issues/\n"

--- a/tests/test_auto_notify_send.zunit
+++ b/tests/test_auto_notify_send.zunit
@@ -108,8 +108,8 @@
     run _auto_notify_send
 
     assert $state equals 0
-    assert "$lines[1]" same_as '-e display notification "Total time: 20 seconds'
-    assert "$lines[2]" same_as 'Exit code: 0" with title "\"f bar -r\" Completed"'
+    assert "$lines[1]" same_as '-e on run argv -e display notification (item 1 of argv) with title (item 2 of argv) -e end run Total time: 20 seconds'
+    assert "$lines[2]" same_as 'Exit code: 0 "f bar -r" Completed'
 }
 
 @test 'auto-notify-send sends warning on unsupported platform' {

--- a/tests/test_auto_notify_send.zunit
+++ b/tests/test_auto_notify_send.zunit
@@ -92,7 +92,7 @@
     assert "$lines[4]" same_as "--urgency=normal --expire-time=15000"
 }
 
-@test 'auto-notify-send sends notification on MacOSX' {
+@test 'auto-notify-send sends notification on macOS' {
     AUTO_COMMAND="f bar -r"
     AUTO_COMMAND_FULL="foo bar -r"
     AUTO_COMMAND_START=11080


### PR DESCRIPTION
Now body and title are passed as arguments to `osascript` instead of string escaping. This reduces edge cases from AppleScript's escape sequences. For example, previously I was able to crash your plugin with the following command:

```shell
echo '\"'; sleep 10
```