### PR TITLE
feat(macos): Optionally add sound to notification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,15 @@ An example of how these values can be set is shown below:
     export AUTO_NOTIFY_TITLE="Hey! %command has just finished"
     export AUTO_NOTIFY_BODY="It completed in %elapsed seconds with exit code %exit_code"
 
+**Notificaton Sound**
+
+The notification can also trigger playing a short sound by changing ``AUTO_NOTIFY_USE_SOUND``.
+NOTE: This configuration option currently only works for macOS.
+
+::
+    # Enable using sound (default: 0)
+    export AUTO_NOTIFY_USE_SOUND=1
+
 **Notification Expiration Time**
 
 You can set how long a notification sent by ``auto-notify`` will remain showing by setting the environment

--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -42,12 +42,15 @@ function _auto_notify_message() {
     # Run using echo -e in order to make sure notify-send picks up new line
     local DEFAULT_TITLE="\"%command\" Completed"
     local DEFAULT_BODY="$(echo -e "Total time: %elapsed seconds\nExit code: %exit_code")"
+    local DEFAULT_USE_SOUND=0
 
     local title="${AUTO_NOTIFY_TITLE:-$DEFAULT_TITLE}"
     local text="${AUTO_NOTIFY_BODY:-$DEFAULT_BODY}"
+    local use_sound=${AUTO_NOTIFY_USE_SOUND:=$DEFAULT_USE_SOUND}
 
     title="$(_auto_notify_format "$title" "$command" "$elapsed" "$exit_code")"
     body="$(_auto_notify_format "$text" "$command" "$elapsed" "$exit_code")"
+    [[ $use_sound -eq 1 ]] && sound='sound name ""'
 
     if [[ "$platform" == "Linux" ]]; then
         local urgency="normal"
@@ -60,7 +63,7 @@ function _auto_notify_message() {
     elif [[ "$platform" == "Darwin" ]]; then
         osascript \
           -e 'on run argv' \
-          -e 'display notification (item 1 of argv) with title (item 2 of argv)' \
+          -e "display notification (item 1 of argv) with title (item 2 of argv) $sound" \
           -e 'end run' \
           "$body" "$title"
     else


### PR DESCRIPTION
Add an option `AUTO_NOTIFY_USE_SOUND` (default: `0` / false) to sound the system default notification sound when the notification appears. Only works on macOS.