### PR TITLE
Fix transient argument

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ test: &test
     - checkout
     - run:
         name: Install Dependencies
-        command: apt-get update && apt-get install -y curl git ncurses-bin
+        command: apt-get update && apt-get install -y curl git ncurses-bin libnotify-bin
     - run:
         name: Download requirements
         command: |
@@ -25,7 +25,7 @@ test: &test
 jobs:
   lint:
     docker:
-      - image: "python:3.7-stretch"
+      - image: "python:3.11"
     steps:
       - checkout
       - run:

--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -56,7 +56,7 @@ function _auto_notify_message() {
             urgency="critical"
             transient=""
         fi
-        notify-send "$title" "$body" --app-name=zsh "$transient" "--urgency=$urgency" "--expire-time=$AUTO_NOTIFY_EXPIRE_TIME"
+        notify-send "$title" "$body" --app-name=zsh $transient "--urgency=$urgency" "--expire-time=$AUTO_NOTIFY_EXPIRE_TIME"
     elif [[ "$platform" == "Darwin" ]]; then
         osascript \
           -e 'on run argv' \

--- a/tests/test_auto_notify_send.zunit
+++ b/tests/test_auto_notify_send.zunit
@@ -89,7 +89,7 @@
     assert "$lines[1]" same_as 'Notification Title: "f bar -r" Completed'
     assert "$lines[2]" same_as "Notification Body: Total time: 20 seconds"
     assert "$lines[3]" same_as "Exit code: 0"
-    assert "$lines[4]" same_as "--app-name=zsh --urgency=normal --expire-time=15000"
+    assert "$lines[4]" same_as "--app-name=zsh --transient --urgency=normal --expire-time=15000"
 }
 
 @test 'auto-notify-send sends notification on macOS' {


### PR DESCRIPTION
The transient variable must not be quoted. Otherwise the command fails with `Invalid number of options` for unsuccessful error codes.