### PR TITLE
Add configuration options for notification urgency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,18 @@ An example of how these values can be set is shown below:
     export AUTO_NOTIFY_TITLE="Hey! %command has just finished"
     export AUTO_NOTIFY_BODY="It completed in %elapsed seconds with exit code %exit_code"
 
+**Notification Urgency Level**
+
+By default, commands that exit successfully (with code 0) will send out a notification with the urgency level of "normal", while commands that exit with an error (code > 0), will use level "critical".
+On some systems (e.g. KDE or Gnome) critical notifications are not desirable as they might never expire.
+You can override notification urgency levels by setting the appropriate environment variables ``AUTO_NOTIFY_URGENCY_ON_SUCCESS`` or ``AUTO_NOTIFY_URGENCY_ON_ERROR`` to either ``low``, ``normal``, or ``critical``.
+NOTE: This configuration option currently only works for Linux.
+
+::
+
+    # Set notification urgency level on error to normal
+    export AUTO_NOTIFY_URGENCY_ON_ERROR="normal"
+
 **Notification Expiration Time**
 
 You can set how long a notification sent by ``auto-notify`` will remain showing by setting the environment

--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -33,6 +33,12 @@ export AUTO_NOTIFY_VERSION="0.11.1"
         'ssh'
         'nano'
     )
+# Default notification urgency for successful exit codes
+[[ -z "$AUTO_NOTIFY_URGENCY_ON_SUCCESS" ]] &&
+    export AUTO_NOTIFY_URGENCY_ON_SUCCESS="normal"
+# Default notification urgency for error exit codes
+[[ -z "$AUTO_NOTIFY_URGENCY_ON_ERROR" ]] &&
+    export AUTO_NOTIFY_URGENCY_ON_ERROR="critical"
 
 function _auto_notify_format() {
     local MESSAGE="$1"
@@ -68,18 +74,18 @@ function _auto_notify_message() {
 
     if [[ "$platform" == "Linux" ]]; then
         # Set default notification properties
-        local urgency="normal"
+        local urgency="$AUTO_NOTIFY_URGENCY_ON_SUCCESS"
         local transient="--hint=int:transient:$AUTO_NOTIFY_ENABLE_TRANSIENT"
         local icon="${AUTO_NOTIFY_ICON_SUCCESS:-""}"
 
         # Handle specific exit codes
         if [[ "$exit_code" -eq 130 ]]; then
-            urgency="critical"
+            urgency="$AUTO_NOTIFY_URGENCY_ON_ERROR"
             transient="--hint=int:transient:1"
             icon="${AUTO_NOTIFY_ICON_FAILURE:-""}"
         elif [[ "$exit_code" -ne 0 ]]; then
             # For all other non-zero exit codes, mark the notification as critical.
-            urgency="critical"
+            urgency="$AUTO_NOTIFY_URGENCY_ON_ERROR"
             icon="${AUTO_NOTIFY_ICON_FAILURE:-""}"
         fi
 

--- a/tests/test_auto_notify_send.zunit
+++ b/tests/test_auto_notify_send.zunit
@@ -157,3 +157,19 @@
     assert "$lines[1]" same_as 'Notification Title: doom -i has completed in 45s yo'
     assert "$lines[2]" same_as "Notification Body: doom -i exited with code 0"
 }
+
+@test 'auto-notify-send sends notification with low urgency' {
+    AUTO_COMMAND="f bar -r"
+    AUTO_COMMAND_FULL="foo bar -r"
+    AUTO_COMMAND_START=11080
+    AUTO_NOTIFY_URGENCY_ON_SUCCESS="low"
+    AUTO_NOTIFY_URGENCY_ON_ERROR="critical"
+    AUTO_NOTIFY_EXPIRE_TIME=8000
+    run _auto_notify_send
+
+    assert $state equals 0
+    assert "$lines[1]" same_as 'Notification Title: "f bar -r" Completed'
+    assert "$lines[2]" same_as "Notification Body: Total time: 20 seconds"
+    assert "$lines[3]" same_as "Exit code: 0"
+    assert "$lines[4]" same_as "--app-name=zsh --hint=int:transient:1 --urgency=low --expire-time=8000"
+}


### PR DESCRIPTION
Builds upon and replaces #24 

Gives the user access to 2 configuration options that affect what urgency is used for the notification.
- `AUTO_NOTIFY_URGENCY_ON_SUCCESS`
- `AUTO_NOTIFY_URGENCY_ON_ERROR`

I've also added a test case for the `ON_SUCCESS` urgency option. I was unfortunately not able to figure out how to add a test case for the `ON_ERROR` option without modifying unrelated parts of the code quite heavily.
I've also added a section in the README, but I'm unfamiliar with the formatting, and my VS Code extension is not rendering it properly, so I just copied the style and hope it works :)