### PR TITLE
match whole words in commands

### DIFF
--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -89,7 +89,7 @@ function _is_auto_notify_ignored() {
 
     if [[ -n "$AUTO_NOTIFY_WHITELIST" ]]; then
         for allowed in $AUTO_NOTIFY_WHITELIST; do
-            if [[ "$target_command" == "$allowed"* ]]; then
+            if [[ "$target_command" == "$allowed"(| *) ]]; then
                 print "no"
                 return
             fi
@@ -97,7 +97,7 @@ function _is_auto_notify_ignored() {
         print "yes"
     else
         for ignore in $AUTO_NOTIFY_IGNORE; do
-            if [[ "$target_command" == "$ignore"* ]]; then
+            if [[ "$target_command" == "$ignore"*(| *) ]]; then
                 print "yes"
                 return
             fi


### PR DESCRIPTION
If e.g. you have a AUTO_NOTIFY_WHITELIST=d, notify on "d" but not on "diff".