### PR TITLE
Add Icon Support to Linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,17 @@ then all the values in ``AUTO_NOTIFY_IGNORE`` are not used.
 
     export AUTO_NOTIFY_WHITELIST=("apt-get" "docker")
 
+**Adding an icon - Linux**
+
+If you wish to have an icon displayed on command success and/or failure, you can do so by defining the environmental variables ``AUTO_NOTIFY_ICON_SUCCESS`` and ``AUTO_NOTIFY_ICON_FAILURE`` respectively.
+
+::
+
+    export AUTO_NOTIFY_ICON_SUCCESS=/path/to/success/icon.png
+    export AUTO_NOTIFY_ICON_FAILURE=/path/to/failure/icon.png
+
+
+
 Temporarily Disabling Notifications
 -----------------------------------
 

--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -61,10 +61,10 @@ function _auto_notify_message() {
         fi
 	local icon_arg=""
 	if [[ -n "$icon" ]]; then
-		icon_arg=" --icon=$icon"
+		icon_arg="--icon=$icon"
 	fi
 	
-        notify-send "$title" "$body" --app-name=zsh $transient "--urgency=$urgency" "--expire-time=$AUTO_NOTIFY_EXPIRE_TIME$icon_arg" 
+        notify-send "$title" "$body" --app-name=zsh $transient "--urgency=$urgency" "--expire-time=$AUTO_NOTIFY_EXPIRE_TIME" "$icon_arg" 
     elif [[ "$platform" == "Darwin" ]]; then
         osascript \
           -e 'on run argv' \

--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -1,4 +1,4 @@
-export AUTO_NOTIFY_VERSION="0.8.1"
+export AUTO_NOTIFY_VERSION="0.8.2"
 
 # Time it takes for a notification to expire
 [[ -z "$AUTO_NOTIFY_EXPIRE_TIME" ]] &&
@@ -6,6 +6,7 @@ export AUTO_NOTIFY_VERSION="0.8.1"
 # Threshold in seconds for when to automatically show a notification
 [[ -z "$AUTO_NOTIFY_THRESHOLD" ]] &&
     export AUTO_NOTIFY_THRESHOLD=10
+
 # List of commands/programs to ignore sending notifications for
 [[ -z "$AUTO_NOTIFY_IGNORE" ]] &&
     export AUTO_NOTIFY_IGNORE=(
@@ -52,11 +53,18 @@ function _auto_notify_message() {
     if [[ "$platform" == "Linux" ]]; then
         local urgency="normal"
         local transient="--hint=int:transient:1"
+        local icon=${AUTO_NOTIFY_ICON_SUCCESS:-""}
         if [[ "$exit_code" != "0" ]]; then
             urgency="critical"
             transient=""
+            icon=${AUTO_NOTIFY_ICON_FAILURE:-""}
         fi
-        notify-send "$title" "$body" --app-name=zsh $transient "--urgency=$urgency" "--expire-time=$AUTO_NOTIFY_EXPIRE_TIME"
+	local icon_arg=""
+	if [[ -n "$icon" ]]; then
+		icon_arg=" --icon=$icon"
+	fi
+	
+        notify-send "$title" "$body" --app-name=zsh $transient "--urgency=$urgency" "--expire-time=$AUTO_NOTIFY_EXPIRE_TIME$icon_arg" 
     elif [[ "$platform" == "Darwin" ]]; then
         osascript \
           -e 'on run argv' \

--- a/tests/test_auto_notify_send.zunit
+++ b/tests/test_auto_notify_send.zunit
@@ -92,6 +92,21 @@
     assert "$lines[4]" same_as "--app-name=zsh --hint=int:transient:1 --urgency=normal --expire-time=15000"
 }
 
+@test 'auto-notify-send sends notification and icon on Linux on success' {
+    AUTO_COMMAND="f bar -r"
+    AUTO_COMMAND_FULL="foo bar -r"
+    AUTO_COMMAND_START=11080
+    AUTO_NOTIFY_EXPIRE_TIME=15000
+    AUTO_NOTIFY_ICON_SUCCESS=/path/to/success/icon.png
+    run _auto_notify_send
+
+    assert $state equals 0
+    assert "$lines[1]" same_as 'Notification Title: "f bar -r" Completed'
+    assert "$lines[2]" same_as "Notification Body: Total time: 20 seconds"
+    assert "$lines[3]" same_as "Exit code: 0"
+    assert "$lines[4]" same_as "--app-name=zsh --hint=int:transient:1 --urgency=normal --expire-time=15000 --icon=/path/to/success/icon.png"
+}
+
 @test 'auto-notify-send sends notification on macOS' {
     AUTO_COMMAND="f bar -r"
     AUTO_COMMAND_FULL="foo bar -r"

--- a/tests/test_auto_notify_send.zunit
+++ b/tests/test_auto_notify_send.zunit
@@ -89,7 +89,7 @@
     assert "$lines[1]" same_as 'Notification Title: "f bar -r" Completed'
     assert "$lines[2]" same_as "Notification Body: Total time: 20 seconds"
     assert "$lines[3]" same_as "Exit code: 0"
-    assert "$lines[4]" same_as "--app-name=zsh --hint=int:transient:1 --urgency=normal --expire-time=15000"
+    assert "$lines[4]" same_as "--app-name=zsh --hint=int:transient:1 --urgency=normal --expire-time=15000 "
 }
 
 @test 'auto-notify-send sends notification and icon on Linux on success' {


### PR DESCRIPTION
# Add Icon Support to Linux

## Description

Notify-send allows for an --icon argument that displays an icon with the notification, this pull request allows the user to specify an icon to use for a successful command as well as a failed one with `AUTO_NOTIFY_ICON_SUCCESS` and `AUTO_NOTIFY_ICON_FAILURE` respectively.

## Limitations

I don't have a Mac to test with so this feature only works with Linux so far

## Changes
- Added logic to _auto_notify_message to add icon arg
- Added test to check if icon arg added after successful command
- Modified test to pass if icon arg not added as blank space is now present at end of output
- Added section to docs explaining configuration for success and failure icons