### PR TITLE
Unquote $icon in `notify-send` command

### DIFF
--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -64,7 +64,7 @@ function _auto_notify_message() {
 		icon_arg="--icon=$icon"
 	fi
 
-        notify-send "$title" "$body" --app-name=zsh $transient "--urgency=$urgency" "--expire-time=$AUTO_NOTIFY_EXPIRE_TIME" "$icon_arg"
+        notify-send "$title" "$body" --app-name=zsh $transient "--urgency=$urgency" "--expire-time=$AUTO_NOTIFY_EXPIRE_TIME" $icon_arg
     elif [[ "$platform" == "Darwin" ]]; then
         osascript \
           -e 'on run argv' \


### PR DESCRIPTION
If `AUTO_NOTIFY_ICON_SUCCESS` or `AUTO_NOTIFY_ICON_FAILURE` is not set, the command fails with `Invalid number of options` since `$icon` is empty.