### PR TITLE
Treat code 130 as success

### DIFF
--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -54,7 +54,7 @@ function _auto_notify_message() {
         local urgency="normal"
         local transient="--hint=int:transient:1"
         local icon=${AUTO_NOTIFY_ICON_SUCCESS:-""}
-        if [[ "$exit_code" != "0" ]]; then
+        if [[ "$exit_code" != "0" ]] && [[ "$exit_code" != "130" ]]; then
             urgency="critical"
             transient=""
             icon=${AUTO_NOTIFY_ICON_FAILURE:-""}


### PR DESCRIPTION
Exit code 130 is returned when a process is terminated with SIGINT (^C, Break). This happens frequently enough that the notification becomes an annoyance since it needs to be manually dismissed. This patch treats 130 as a success because typically, the user is already interacting with the program and doesn't need a persistent notification.