### PR TITLE
add reading ignored commands from a file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,18 @@ a new array.
     # redefine what is ignored by auto-notify
     export AUTO_NOTIFY_IGNORE=("docker" "man" "sleep")
 
+Commands from the file auto-notify-ignored.txt are also also appended to the ``AUTO_NOTIFY_IGNORE`` variable.
+This file is searched for in ``$ZDOTDIR``, or in your home dir if ``$ZDOTDIR`` isn't exported.
+You might have to create it, it isn't there by default.
+Each line in this file will be appended as one item (command) to the array.
+If you wish to use custom location and/or name of the auto-notify-ignored.txt file,
+then set ``AUTO_NOTIFY_IGNORE_FILE``` variable to your custom path.
+
+::
+
+    # set custom path to an ignore file
+    export AUTO_NOTIFY_IGNORE_FILE="${HOME}/Documents/my-custom-ignore.txt"
+
 **Using a Whitelist to ignore commands**
 
 If you wish to use a whitelist approach instead of the default blacklist approach used by ``AUTO_NOTIFY_IGNORE``,

--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -6,6 +6,9 @@ export AUTO_NOTIFY_VERSION="0.10.2"
 # Threshold in seconds for when to automatically show a notification
 [[ -z "$AUTO_NOTIFY_THRESHOLD" ]] &&
     export AUTO_NOTIFY_THRESHOLD=10
+# Path to auto-notify-ignored.txt - file with ignored commands 
+[[ -z "$AUTO_NOTIFY_IGNORE_FILE" ]] &&
+    export AUTO_NOTIFY_IGNORE_FILE="${ZDOTDIR:-$HOME}/auto-notify-ignored.txt"
 
 # List of commands/programs to ignore sending notifications for
 [[ -z "$AUTO_NOTIFY_IGNORE" ]] &&
@@ -23,6 +26,16 @@ export AUTO_NOTIFY_VERSION="0.10.2"
         'ssh'
         'nano'
     )
+
+# If AUTO_NOTIFY_WHITELIST isn't defined, read the file in AUTO_NOTIFY_IGNORE_FILE
+# and append each line in that file to AUTO_NOTIFY_IGNORE array
+if [[ -z "$AUTO_NOTIFY_WHITELIST" ]]; then
+    if [[ -e "$AUTO_NOTIFY_IGNORE_FILE" ]]; then
+        while IFS= read -r line; do
+            AUTO_NOTIFY_IGNORE+=("$line")
+        done < "$AUTO_NOTIFY_IGNORE_FILE"
+    fi
+fi
 
 function _auto_notify_format() {
     local MESSAGE="$1"


### PR DESCRIPTION
Hi, this PR allows reading list of ignored commands from a file. I also added explanation of it to the README. This allows implementing https://github.com/MichaelAquilina/zsh-auto-notify/issues/65 later, but is usefull on it's own.