### PR TITLE
macOS: suppress unwanted `ApplePersistence` spam

### DIFF
--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -109,6 +109,8 @@ function _auto_notify_message() {
           -e 'end run' \
           "$body" "$title" \
           2> >(grep -Ev 'ApplePersistence=(NO|YES)' >&2)
+          # ^ osascript outputs "ApplePersistence=NO" to stderr on every run, which clutters the terminal.
+          # ^ Filter stderr to remove only this message while preserving any legitimate error messages.
     else
         printf "Unknown platform for sending notifications: $platform\n"
         printf "Please post an issue on gitub.com/MichaelAquilina/zsh-auto-notify/issues/\n"

--- a/auto-notify.plugin.zsh
+++ b/auto-notify.plugin.zsh
@@ -107,7 +107,8 @@ function _auto_notify_message() {
           -e 'on run argv' \
           -e 'display notification (item 1 of argv) with title (item 2 of argv)' \
           -e 'end run' \
-          "$body" "$title"
+          "$body" "$title" \
+          2> >(grep -Ev 'ApplePersistence=(NO|YES)' >&2)
     else
         printf "Unknown platform for sending notifications: $platform\n"
         printf "Please post an issue on gitub.com/MichaelAquilina/zsh-auto-notify/issues/\n"


### PR DESCRIPTION
Every time the osascript is run the following message would clutter the user's terminal:

```
2025-06-03 17:42:31.716 osascript[87001:4802580] ApplePersistence=NO
```

`osascript` provides no option to suppress this output, and redirecting `stderr` to `/dev/null` would hide legitimate errors as well. So instead I'm selectively filtering the `stderr` to remove that message and nothing else.
